### PR TITLE
As default json

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ class Foo
 end
 ```
 
-If `#as_json` is called without the `:presenter_action` options, or if the
-presenter class doesn't exist, this delegates to the original model class
-definition of `#as_json`
+If `#as_json` is called without the `:presenter_action` options, or if
+the presenter class doesn't exist, this delegates to
+`#as_default_json`. The default implementation of `#as_default_json`
+in turn delegates to the original model class definition of `#as_json`.
 
 Your presenter class can technically be any PORO that responds to `#as_json`,
 but there is a handy base class, `AsJsonPresentable::Presenter` that you

--- a/as_json_presentable.gemspec
+++ b/as_json_presentable.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'as_json_presentable'
-  s.version     = '0.0.2'
+  s.version     = '0.0.3'
   s.date        = '2015-10-16'
   s.summary     = "JSON presenter"
   s.description = "This is a simple implementation of the presenter pattern for JSON presentation."

--- a/lib/as_json_presentable/presenter.rb
+++ b/lib/as_json_presentable/presenter.rb
@@ -27,14 +27,18 @@ module AsJsonPresentable
       if has_presenter_method?(presenter_action)
         send(presenter_method(presenter_action), options)
       else
-        resource.as_json(options)
+        as_default_json(options)
       end
     end
 
-   # return object errors
-  def as_error_json(options=nil)
-    { errors: resource.errors }
-  end
+    def as_default_json(options=nil)
+      resource.as_json(options)
+    end
+
+    # return object errors
+    def as_error_json(options=nil)
+      { errors: resource.errors }
+    end
 
   private
 

--- a/spec/as_json_presentable/presenter_spec.rb
+++ b/spec/as_json_presentable/presenter_spec.rb
@@ -21,6 +21,10 @@ module AsJsonPresentable
           expect(resource).to receive(:as_json).once
           subject.as_json
         end
+        it "falls back to as_default_json" do
+          expect(subject).to receive(:as_default_json).once
+          subject.as_json
+        end
       end
 
       context "with an invalid :presenter_action" do


### PR DESCRIPTION
Instead of defaulting to `object.as_json`, defaults to `presenter.as_default_json`. The provided implementation of `as_default_json` delegates to `object.as_json` so this should be backwards compatible
